### PR TITLE
Fox Jinja2 build error

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -5,6 +5,9 @@
 git+https://github.com/matthew-brett/jupyter-book.git@deepnote-button
 # Remove this next one when PRs merged (it's a dependency of jupyter-book).
 git+https://github.com/matthew-brett/sphinx-book-theme.git@deepnote-button
+# To avoid a Sphinx error:
+# https://github.com/readthedocs/readthedocs.org/issues/9038#issuecomment-1078927910
+jinja2<3.1
 
 # To allow static build / upload
 ghp-import


### PR DESCRIPTION
The error was:

```
  File "/Users/mb312/.virtualenvs/test/lib/python3.9/site-packages/sphinx/util/rst.py", line 21, in <module>
    from jinja2 import Environment, environmentfilter
ImportError: cannot import name 'environmentfilter' from 'jinja2' (/Users/mb312/.virtualenvs/test/lib/python3.9/site-packages/jinja2/__init__.py)
```

The cause was the removal of `environmentfilter` from the Jinja2,
apparently in Jinja2 3.1.

See: https://github.com/sphinx-doc/sphinx/issues/10291 for discussion.